### PR TITLE
Easier and ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+script: bundle exec rake test
+language: ruby
+rvm:
+  - ruby-head
+  - 1.9.3
+  - 2.1
+  - 2.2
+  - 2.3
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: 2.3
+
+cache: bundler
+sudo: true
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y liblua5.1-dev

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,13 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rdoc/task'
+require 'rake/extensiontask'
 
-RSpec::Core::RakeTask.new(:test)
+RSpec::Core::RakeTask.new(:test => [:compile])
+
+Rake::ExtensionTask.new 'rlua' do |ext|
+  ext.ext_dir = 'ext'
+end
 
 Rake::RDocTask.new do |rd|
   rd.main        = 'README.rdoc'

--- a/rlua.gemspec
+++ b/rlua.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rdoc'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake-compiler'
   gem.add_development_dependency 'hanna-nouveau'
   gem.add_development_dependency 'rspec'
 


### PR DESCRIPTION
This PR adds rake-compiler for automated compiling when needed before the tests when `rake test` is called. It also adds a travis-configuration.