### PR TITLE
Fix/lua5.3 integer and lib loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - rvm: ruby-head
 cache: bundler
 before_install:
-  - gem install -v 1.17.2 bundler
+  - gem install -v 1.17.3 bundler
   - sudo apt-get update -qq
   - sudo apt-get install -y liblua5.3-dev
 script: bundle exec rake test

--- a/ext/rlua.c
+++ b/ext/rlua.c
@@ -72,7 +72,11 @@ static VALUE rlua_get_var(lua_State *state)
       return lua_toboolean(state, -1) ? Qtrue : Qfalse;
 
     case LUA_TNUMBER:
-      return rb_float_new(lua_tonumber(state, -1));
+      if (lua_isinteger(state, -1)) {
+        return INT2FIX(lua_tointeger(state, -1));
+      } else {
+        return rb_float_new(lua_tonumber(state, -1));
+      }
 
     case LUA_TSTRING: {
       size_t length;
@@ -105,7 +109,7 @@ static void rlua_push_var(lua_State *state, VALUE value)
       break;
     }
     case T_FIXNUM:
-      lua_pushnumber(state, FIX2INT(value));
+      lua_pushinteger(state, FIX2LONG(value));
       break;
 
     case T_BIGNUM:

--- a/rlua.gemspec
+++ b/rlua.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
   gem.requirements << 'liblua 5.3'
 
-  gem.add_development_dependency 'bundler', '~> 1.10'
+  gem.add_development_dependency 'bundler', '>= 1.10'
   gem.add_development_dependency 'rdoc'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rake-compiler'

--- a/spec/rlua_spec.rb
+++ b/spec/rlua_spec.rb
@@ -248,5 +248,21 @@ describe Lua::State do
         expect(subject.value["a"].class).to eq(Lua::Function)
       end
     end
+
+    context '__load_stdlib' do
+      it "creates a global name for most libraries" do
+        [:math, :table, :utf8, :io, :os, :package].each do |lib|
+          subject.__load_stdlib(lib)
+          subject.__eval "value = (#{lib} == nil)"
+          expect(subject.value).to eq(false)
+        end
+      end
+
+      it "does not create a global name when loading base" do
+        subject.__load_stdlib("base")
+        subject.__eval "value = (base == nil)"
+        expect(subject.value).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
#11 broke some functionalities.

Lua 5.1 luaopen_* functions did all the job of setting the global name. In 5.3 the loading mechanism changed a bit. This caused no global name being set (`__load_stdib(:debug)` didn't set a `debug` variable).

Lua 5.3 added support for integers, as a subtype of `number`. They're now enforcing `next()` in arrays to receive integer keys, and rlua was converting `number`s to `float`s, which broke `Lua::Table#each`.

Added some tests for both breakages.